### PR TITLE
Prevent completion from halting on tags load error

### DIFF
--- a/ac-etags.el
+++ b/ac-etags.el
@@ -67,7 +67,12 @@
 (defvar ac-etags--completion-cache (make-hash-table :test 'equal))
 
 (defun ac-etags--cache-candidates (prefix)
-  (let ((candidates (all-completions prefix (tags-completion-table))))
+  (let ((candidates
+         (all-completions
+          prefix
+          (with-demoted-errors "%s"
+            (tags-completion-table)
+            ))))
     (puthash prefix candidates ac-etags--completion-cache)
     candidates))
 


### PR DESCRIPTION
Addresses issue if one or more elements of `tags-table-list` are not present, `(tags-completion-table)` throws an error, completion stops even if there would be other valid completion sources in `ac-sources`.  Now instead, a user error is emitted but completion can continue.
